### PR TITLE
Updating <dc:date> value format in search RSS template

### DIFF
--- a/Products/CMFPlone/browser/syndication/templates/search-rss.pt
+++ b/Products/CMFPlone/browser/syndication/templates/search-rss.pt
@@ -46,7 +46,7 @@
     <tal:block tal:repeat="cat item/categories">
       <dc:subject tal:content="cat">Item</dc:subject>
     </tal:block>
-    <dc:date tal:content="item/published|item/modified">Published or last modified date if no published date</dc:date>
+    <dc:date tal:content="item/published/HTML4|item/modified/HTML4">Published or last modified date if no published date</dc:date>
     <dc:type tal:content="item/context/Type">Type</dc:type>
   </item>
 </tal:block>


### PR DESCRIPTION
The updated date format matches the format 'standard' RSS template. This fixes an issue where the feedparser product couldn't resolve the date because it didn't match one of its parseable formats.